### PR TITLE
POM fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
@@ -48,9 +49,6 @@
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.1</version>
-        <configuration>
-          <releaseProfiles>release</releaseProfiles>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -115,9 +113,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.8</version>
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.1</version>
       </plugin>
     </plugins>
   </reporting>
@@ -130,25 +130,26 @@
     </license>
   </licenses>
 
-  <profiles> 
-    <profile> 
-      <id>release</id> 
-      <build> 
-        <plugins> 
-          <plugin> 
-            <artifactId>maven-gpg-plugin</artifactId> 
-            <executions> 
-              <execution> 
-                <id>sign-artifacts</id> 
-                <phase>verify</phase> 
-                <goals> 
-                  <goal>sign</goal> 
-                </goals> 
-              </execution> 
-            </executions> 
-          </plugin> 
-        </plugins> 
-      </build> 
-    </profile> 
-  </profiles> 
+  <profiles>
+    <profile>
+      <id>release-profile</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Stapler 1.235 release did not work. @kohsuke had tried to release several times but the [staging repos](https://oss.sonatype.org/#stagingRepositories) had validation errors such as 
- `Missing Signature: '/org/kohsuke/stapler/stapler/1.235/stapler-1.235-javadoc.jar.asc' does not exist for 'stapler-1.235-javadoc.jar'.`
- `Missing Signature: '/org/kohsuke/stapler/stapler-jrebel/1.235/stapler-jrebel-1.235.jar.asc' does not exist for 'stapler-jrebel-1.235.jar'.`
- `Missing Signature: '/org/kohsuke/stapler/stapler-jrebel/1.235/stapler-jrebel-1.235-javadoc.jar.asc' does not exist for 'stapler-jrebel-1.235-javadoc.jar'.`

Perhaps some problem with the Nexus plugin? Various artifacts were missing from the staging repos, with no clear pattern.

I tried to perform a manual release from the tag (`mvn -P release deploy`) but this did not work, apparently because `*-sources.jar` and `*-javadoc.jar` were missing. Apparently the parent POM specifies a different profile than the standard one for releases, and uses this to add in `maven-gpg-plugin`. I did not encounter any problem with the Nexus plugin; the deployment looked complete.

Note that `org.sonatype.oss:oss-parent:9` also specifies an alternate release profile, including GPG support. There is no comment explaining why. At any rate, that profile explicitly includes `maven-source-plugin` and `maven-javadoc-plugin`.

@reviewbybees
