### PR TITLE
Specify versions of some maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
@@ -115,9 +116,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.8.1</version>
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.3</version>
       </plugin>
     </plugins>
   </reporting>
@@ -163,7 +166,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.7</version>
+            <version>2.10.3</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>


### PR DESCRIPTION
When I run `mvn clean package` in the `github-api` project, I got the following warnings:

```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kohsuke:github-api:jar:1.71-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ org.kohsuke:pom:14, /Users/vbauer/.m2/repository/org/kohsuke/pom/14/pom-14.pom, line 41, column 15
[WARNING] 'reporting.plugins.plugin.version' for org.apache.maven.plugins:maven-project-info-reports-plugin is missing. @ org.kohsuke:pom:14, /Users/vbauer/.m2/repository/org/kohsuke/pom/14/pom-14.pom, line 115, column 15
[WARNING] 'reporting.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ line 155, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

To fix this problems it is necessary to specify versions of the following Maven plugins:
- maven-compiler-plugin
- maven-project-info-reports-plugin
- maven-javadoc-plugin
