### PR TITLE
Use source:jar, not source:jar-no-fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,15 @@
   </developers>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.10.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -127,7 +136,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
       </plugin>
     </plugins>
   </reporting>
@@ -165,7 +173,7 @@
               <execution>
                 <id>attach-sources</id>
                 <goals>
-                  <goal>jar-no-fork</goal>
+                  <goal>jar</goal>
                 </goals>
               </execution>
             </executions>
@@ -173,7 +181,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.3</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>


### PR DESCRIPTION
Although the [OSSRH guide does suggest](http://central.sonatype.org/pages/apache-maven.html#javadoc-and-sources-attachments) `source:jar-no-fork`, the standard `release-profile` in the [super POM](http://maven.apache.org/ref/3.0.4/maven-model-builder/super-pom.html) uses `source:jar`; both use `javadoc:jar`. Not sure I understand the ramifications but seems like these should be consistent. Noticed because I found that inside a forked execution from `release:perform`, both `source:jar` *and* `source:jar-no-fork` were run, thus attaching `*-sources.jar` twice; `deploy:deploy` tries to deploy each, so if an alternate deployment repository forbids overwriting of artifacts, the second upload will fail, breaking the release.

Also pinning version of javadoc plugin to avoid a warning.