### PR TITLE
Back to source:jar-no-fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
               <execution>
                 <id>attach-sources</id>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>jar-no-fork</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
Reverts the main part of #4 so as to follow apache/maven#168 in Maven 3.5.4.