### PR TITLE
Update dependencies for Java 21 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
   <version>22-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Root POM for Kohsuke's projects</name>
-  <url>http://kohsuke.org/</url>
+  <url>https://kohsuke.org/</url>
   <description>${project.name}</description>
 
   <scm>
-    <connection>scm:git:git@github.com/kohsuke/${project.artifactId}.git</connection>
+    <connection>scm:git:https://github.com/kohsuke/${project.artifactId}.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/kohsuke/${project.artifactId}.git</developerConnection>
-    <url>http://${project.artifactId}.kohsuke.org/</url>
+    <url>https://${project.artifactId}.kohsuke.org/</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -42,29 +42,28 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.3</version>
+          <version>3.5.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.11.0</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <release>8</release>
          </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <additionalparam>-Xdoclint:syntax,reference,html</additionalparam>
+          <doclint>syntax,reference,html</doclint>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.1</version>
+        <version>3.0.1</version>
         <configuration>
           <releaseProfiles>release</releaseProfiles>
         </configuration>
@@ -72,7 +71,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.12.1</version>
         <dependencies>
           <dependency>
             <groupId>org.kohsuke</groupId>
@@ -84,7 +83,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>sonatype-nexus-staging</serverId>
@@ -95,7 +94,7 @@
       <plugin>
         <groupId>org.codehaus.gmaven</groupId>
         <artifactId>gmaven-plugin</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
         <executions>
           <execution>
             <goals>
@@ -113,12 +112,12 @@
       <extension>
         <groupId>org.apache.maven.scm</groupId>
         <artifactId>maven-scm-provider-gitexe</artifactId>
-        <version>1.8.1</version>
+        <version>1.13.0</version>
       </extension>
       <extension>
         <groupId>org.apache.maven.scm</groupId>
         <artifactId>maven-scm-manager-plexus</artifactId>
-        <version>1.3</version>
+        <version>1.13.0</version>
       </extension>
       <extension>
         <groupId>org.kohsuke</groupId>
@@ -133,7 +132,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.8.1</version>
+        <version>3.4.5</version>
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -144,7 +143,7 @@
   <licenses>
     <license>
         <name>MIT license</name>
-        <url>http://www.opensource.org/licenses/mit-license.php</url>
+        <url>https://opensource.org/license/mit/</url>
         <distribution>repo</distribution>
     </license>
   </licenses>
@@ -154,22 +153,30 @@
       <id>release</id> 
       <build> 
         <plugins> 
-          <plugin> 
-            <artifactId>maven-gpg-plugin</artifactId> 
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.1.0</version>
             <executions> 
               <execution> 
                 <id>sign-artifacts</id> 
-                <phase>verify</phase> 
-                <goals> 
-                  <goal>sign</goal> 
-                </goals> 
-              </execution> 
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
             </executions> 
           </plugin> 
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.1.2</version>
+            <version>3.3.0</version>
             <executions>
               <execution>
                 <id>attach-sources</id>


### PR DESCRIPTION
Hey @kohsuke,

the change proposed updates dependencies, allowing us to cut releases using maven with Java 21 (or at least 17) in a few jenkinsci repositories, deployed to the central repository.

Would you mind cutting a release afterward?